### PR TITLE
Add tomli dependency for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,6 @@ dependencies = [
     "openai>=1.14",
     "httpx>=0.27",
     "typing-extensions==4.9.0",
+    "tomli; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
## Summary
- add tomli as a conditional dependency so Python 3.9 deployments can import the configuration loader

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3cfc68e888330afc0adf635c34292