### PR TITLE
Ensure providers honor system proxy settings

### DIFF
--- a/src/video_gen/config.py
+++ b/src/video_gen/config.py
@@ -25,6 +25,9 @@ class OpenAISettings:
     image_model: str = "gpt-image-1"
     base_url: Optional[str] = None
     temperature: float = 0.3
+    trust_env: bool = True
+    timeout_seconds: Optional[float] = None
+    verify: Optional[Union[str, bool]] = None
 
 
 @dataclass

--- a/src/video_gen/providers/dashscope_ambience.py
+++ b/src/video_gen/providers/dashscope_ambience.py
@@ -21,6 +21,7 @@ class DashscopeAmbienceClient:
         self._settings = settings
         self._client = httpx.Client(
             timeout=timeout,
+            trust_env=True,
             headers={
                 "Authorization": f"Bearer {settings.api_key}",
                 "Content-Type": "application/json",

--- a/src/video_gen/providers/dashscope_music.py
+++ b/src/video_gen/providers/dashscope_music.py
@@ -21,6 +21,7 @@ class DashscopeMusicClient:
         self._settings = settings
         self._client = httpx.Client(
             timeout=timeout,
+            trust_env=True,
             headers={
                 "Authorization": f"Bearer {settings.api_key}",
                 "Content-Type": "application/json",

--- a/src/video_gen/providers/freesound.py
+++ b/src/video_gen/providers/freesound.py
@@ -17,7 +17,7 @@ class FreesoundClient:
 
     def __init__(self, settings: FreesoundSettings, *, timeout: float = 60.0) -> None:
         self._settings = settings
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, trust_env=True)
 
     def _search(self) -> Optional[dict]:
         params = {

--- a/src/video_gen/providers/mubert.py
+++ b/src/video_gen/providers/mubert.py
@@ -18,7 +18,7 @@ class MubertClient:
 
     def __init__(self, settings: MubertSettings, *, timeout: float = 60.0) -> None:
         self._settings = settings
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, trust_env=True)
 
     def generate_track(self, persona: str, output_path: Path) -> Path:
         payload = {

--- a/src/video_gen/providers/openai_client.py
+++ b/src/video_gen/providers/openai_client.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Iterable, List, Optional, Union
 
+import httpx
 from openai import OpenAI
 
 from ..config import OpenAISettings
@@ -52,7 +53,13 @@ class OpenAIWorkflowClient:
         kwargs = {"api_key": settings.api_key}
         if settings.base_url:
             kwargs["base_url"] = settings.base_url
-        self._client = OpenAI(**kwargs)
+        http_client_kwargs = {"trust_env": settings.trust_env}
+        if settings.timeout_seconds is not None:
+            http_client_kwargs["timeout"] = httpx.Timeout(settings.timeout_seconds)
+        if settings.verify is not None:
+            http_client_kwargs["verify"] = settings.verify
+        http_client = httpx.Client(**http_client_kwargs)
+        self._client = OpenAI(http_client=http_client, **kwargs)
         self._model = settings.model
         self._image_model = settings.image_model
         self._temperature = settings.temperature

--- a/src/video_gen/providers/xunfei.py
+++ b/src/video_gen/providers/xunfei.py
@@ -21,7 +21,7 @@ class XunfeiTTSClient:
 
     def __init__(self, settings: XunfeiSettings, *, timeout: float = 60.0) -> None:
         self._settings = settings
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, trust_env=True)
 
     def synthesize(self, text: str, output_path: Path) -> Path:
         """Synthesize the provided text into an audio file."""


### PR DESCRIPTION
## Summary
- ensure all HTTP client wrappers explicitly trust system proxy configuration
- instantiate the OpenAI workflow client with an httpx client that respects environment proxies
- allow OpenAI workflow settings to control proxy-related HTTPX options so workflow traffic reliably uses the system proxy

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'video_gen')*

------
https://chatgpt.com/codex/tasks/task_e_68e468a5b1c883309b6f287cd9210e22