### PR TITLE
Route OpenAI traffic through local proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cp config/services.example.toml config/services.toml
 ```
 
 2. 按需填写以下字段（示例文件中已标注申请地址）：
-    - **OpenAI**：在 <https://platform.openai.com/account/api-keys> 申请 API Key，用于 GPT-4o 系列与 DALL·E 3 调用。
+    - **OpenAI**：在 <https://platform.openai.com/account/api-keys> 申请 API Key，用于 GPT-4o 系列与 DALL·E 3 调用。若你的机器需要通过本地代理访问 OpenAI，请直接在 `[openai]` 下把 `proxy` 改成自己的代理地址（例如 `http://127.0.0.1:7890`），这样工作流里所有 OpenAI 请求都会自动走这个本地代理；其他服务保持默认配置即可，它们不会再继承系统代理。
     - **讯飞 TTS**：使用科大讯飞“在线语音合成（Text-to-Speech WebAPI v2）”能力，在 <https://www.xfyun.cn/services/online_tts> 创建应用后获取 AppID、APIKey、APISecret。
     - **阿里云 DashScope 音乐生成 / 环境音效**：在 <https://dashscope.aliyun.com/> 注册并开通音频生成能力，单一 API Key 既可用于背景音乐，也可用于生成环境音效。
     - **DeepSeek**（可选）：在 <https://platform.deepseek.com/> 申请 API Key，按需配置自定义 `base_url`、模型、温度，以及网络相关的 `timeout_seconds`、`trust_env`（是否继承系统代理）或 `verify`（证书校验/自签路径），用于人物传记初稿的 LLM 推理。
@@ -61,6 +61,8 @@ cp config/services.example.toml config/services.toml
 
 ```bash
 export OPENAI_API_KEY=sk-...
+export OPENAI_PROXY=http://127.0.0.1:7890   # 如果要走本地代理，请改成自己的端口
+export OPENAI_TRUST_ENV=false               # 默认关闭系统代理继承
 export XUNFEI_APP_ID=...
 export XUNFEI_API_KEY=...
 export XUNFEI_API_SECRET=...
@@ -90,7 +92,7 @@ export IMAGE_GENERATION_PROVIDER=openai  # 可切换为 doubao
 
 未填写或缺失凭证时，系统会自动回退到内置的 Dummy Agent，便于在无真实账号的情况下进行流程验证。
 
-> 💡 如果部署在需要通过企业代理访问外网的环境，保持 `trust_env=true`（默认值）即可让 DeepSeek / 豆包客户端继承系统级代理设置；若代理会替换证书，可设置 `verify=false` 或提供内部 CA 证书路径以避免握手超时。
+> 💡 OpenAI 客户端可以单独通过 `proxy` 字段或 `OPENAI_PROXY` 环境变量指定本地代理；其他服务默认不走代理。若部署在需要通过企业代理访问外网的环境，可为 DeepSeek / 豆包等客户端继续保留 `trust_env=true`（示例配置即为默认值），必要时通过 `verify=false` 或提供内部 CA 证书路径避免握手超时。
 
 如需切换工作流使用的服务，可在 `config/services.toml` 中的 `[text_generation]` 与 `[image_generation]` 模块调整 `provider` 字段：
 

--- a/config/services.example.toml
+++ b/config/services.example.toml
@@ -4,12 +4,16 @@
 api_key = "sk-your-key"
 # Optional custom base url, leave empty to use the default api.openai.com endpoint
 base_url = ""
+# 本地代理地址：如果你的机器需要通过 Clash/Surge 等本地代理访问 OpenAI，请把它改成自己的端口；不需要代理就留空。
+proxy = "http://127.0.0.1:7890"
 # Chat/completions model used for workflow reasoning
 model = "gpt-4o-mini"
 # DALL·E 3 compatible image model identifier
 image_model = "gpt-image-1"
 # Optional temperature override (0-2). Lower keeps outputs deterministic.
 temperature = 0.3
+# 是否继承系统级代理/证书配置，默认关闭，避免和其他服务混用代理。
+trust_env = false
 
 [xunfei_tts]
 # Credentials for the Xunfei (iFlytek) Text-to-Speech WebAPI v2 service

--- a/src/video_gen/config.py
+++ b/src/video_gen/config.py
@@ -25,6 +25,10 @@ class OpenAISettings:
     image_model: str = "gpt-image-1"
     base_url: Optional[str] = None
     temperature: float = 0.3
+    proxy: Optional[str] = None
+    trust_env: bool = False
+    timeout_seconds: Optional[float] = None
+    verify: Optional[Union[str, bool]] = None
 
 
 @dataclass
@@ -155,13 +159,20 @@ def load_service_config(path: Optional[Union[str, Path]] = None) -> ServiceConfi
 
         openai_api_key = _coalesce(os.environ.get("OPENAI_API_KEY"))
         if openai_api_key:
-            data["openai"] = {
+            openai_entry = {
                 "api_key": openai_api_key,
                 "base_url": _coalesce(os.environ.get("OPENAI_BASE_URL")),
                 "model": _coalesce(os.environ.get("OPENAI_MODEL")) or "gpt-4o-mini",
                 "image_model": _coalesce(os.environ.get("OPENAI_IMAGE_MODEL")) or "gpt-image-1",
                 "temperature": float(os.environ.get("OPENAI_TEMPERATURE", 0.3)),
             }
+            proxy = _coalesce(os.environ.get("OPENAI_PROXY"))
+            if proxy:
+                openai_entry["proxy"] = proxy
+            trust_env = _parse_bool(_coalesce(os.environ.get("OPENAI_TRUST_ENV")))
+            if trust_env is not None:
+                openai_entry["trust_env"] = trust_env
+            data["openai"] = openai_entry
 
         xunfei_app_id = _coalesce(os.environ.get("XUNFEI_APP_ID"))
         if xunfei_app_id:

--- a/src/video_gen/providers/dashscope_ambience.py
+++ b/src/video_gen/providers/dashscope_ambience.py
@@ -21,6 +21,7 @@ class DashscopeAmbienceClient:
         self._settings = settings
         self._client = httpx.Client(
             timeout=timeout,
+            trust_env=False,
             headers={
                 "Authorization": f"Bearer {settings.api_key}",
                 "Content-Type": "application/json",

--- a/src/video_gen/providers/dashscope_music.py
+++ b/src/video_gen/providers/dashscope_music.py
@@ -21,6 +21,7 @@ class DashscopeMusicClient:
         self._settings = settings
         self._client = httpx.Client(
             timeout=timeout,
+            trust_env=False,
             headers={
                 "Authorization": f"Bearer {settings.api_key}",
                 "Content-Type": "application/json",

--- a/src/video_gen/providers/freesound.py
+++ b/src/video_gen/providers/freesound.py
@@ -17,7 +17,7 @@ class FreesoundClient:
 
     def __init__(self, settings: FreesoundSettings, *, timeout: float = 60.0) -> None:
         self._settings = settings
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, trust_env=False)
 
     def _search(self) -> Optional[dict]:
         params = {

--- a/src/video_gen/providers/mubert.py
+++ b/src/video_gen/providers/mubert.py
@@ -18,7 +18,7 @@ class MubertClient:
 
     def __init__(self, settings: MubertSettings, *, timeout: float = 60.0) -> None:
         self._settings = settings
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, trust_env=False)
 
     def generate_track(self, persona: str, output_path: Path) -> Path:
         payload = {

--- a/src/video_gen/providers/openai_client.py
+++ b/src/video_gen/providers/openai_client.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Iterable, List, Optional, Union
 
+import httpx
 from openai import OpenAI
 
 from ..config import OpenAISettings
@@ -52,7 +53,17 @@ class OpenAIWorkflowClient:
         kwargs = {"api_key": settings.api_key}
         if settings.base_url:
             kwargs["base_url"] = settings.base_url
-        self._client = OpenAI(**kwargs)
+        http_client_kwargs: dict[str, object] = {}
+        if settings.trust_env is not None:
+            http_client_kwargs["trust_env"] = settings.trust_env
+        if settings.proxy:
+            http_client_kwargs["proxies"] = settings.proxy
+        if settings.timeout_seconds is not None:
+            http_client_kwargs["timeout"] = httpx.Timeout(settings.timeout_seconds)
+        if settings.verify is not None:
+            http_client_kwargs["verify"] = settings.verify
+        http_client = httpx.Client(**http_client_kwargs)
+        self._client = OpenAI(http_client=http_client, **kwargs)
         self._model = settings.model
         self._image_model = settings.image_model
         self._temperature = settings.temperature

--- a/src/video_gen/providers/xunfei.py
+++ b/src/video_gen/providers/xunfei.py
@@ -21,7 +21,7 @@ class XunfeiTTSClient:
 
     def __init__(self, settings: XunfeiSettings, *, timeout: float = 60.0) -> None:
         self._settings = settings
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, trust_env=False)
 
     def synthesize(self, text: str, output_path: Path) -> Path:
         """Synthesize the provided text into an audio file."""


### PR DESCRIPTION
## Summary
- add a dedicated proxy option for OpenAI workflow clients so their traffic is forced through the configured local proxy
- disable system proxy inheritance for the remaining providers to keep them on direct connections
- document the proxy expectations in the README and example services config for plain-language setup guidance

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'video_gen')*

------
https://chatgpt.com/codex/tasks/task_e_68e468a5b1c883309b6f287cd9210e22