### PR TITLE
Ensure OpenAI prompts request JSON output

### DIFF
--- a/src/video_gen/providers/openai_client.py
+++ b/src/video_gen/providers/openai_client.py
@@ -74,6 +74,8 @@ class OpenAIWorkflowClient:
 
     # ----- Helpers -----------------------------------------------------------------
     def _create_json_completion(self, system_prompt: str, user_content: str) -> dict:
+        if "json" not in system_prompt.lower():
+            system_prompt = f"{system_prompt.strip()} Respond with valid JSON."
         response = self._client.chat.completions.create(
             model=self._model,
             temperature=self._temperature,
@@ -100,7 +102,8 @@ class OpenAIWorkflowClient:
         system_prompt = (
             "You are an expert documentary writer. "
             "Produce a concise script about a historical figure strictly in chronological order. "
-            "Always include citations referencing credible sources."
+            "Always include citations referencing credible sources. "
+            "Respond with a JSON object matching the requested structure."
         )
         user_prompt = json.dumps(
             {


### PR DESCRIPTION
## Summary
- append an explicit instruction to JSON-producing system prompts when invoking OpenAI
- update the script generation prompt to call out the required JSON object structure

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'video_gen')*


------
https://chatgpt.com/codex/tasks/task_e_68e4828343f48330b69e382f1810d298