### PR TITLE
Handle OpenAI script responses without sections

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,23 @@
+"""Tests for the OpenAI workflow client helpers."""
+
+from video_gen.providers.openai_client import OpenAIWorkflowClient
+
+
+def test_parse_script_sections_from_plain_string() -> None:
+    data = {"sections": "Intro paragraph.\n\nSecond paragraph."}
+
+    sections = OpenAIWorkflowClient._parse_script_sections(data)
+
+    assert len(sections) == 2
+    assert sections[0].summary == "Intro paragraph."
+    assert sections[1].summary == "Second paragraph."
+
+
+def test_parse_script_sections_from_script_summary() -> None:
+    data = {"script": {"summary": "Single summary returned."}}
+
+    sections = OpenAIWorkflowClient._parse_script_sections(data)
+
+    assert len(sections) == 1
+    assert sections[0].summary == "Single summary returned."
+    assert sections[0].section.startswith("section_")


### PR DESCRIPTION
## Summary
- add a parser helper that normalises loosely structured OpenAI script responses into sections
- fall back to textual summaries when the model omits the expected sections list
- cover the new parsing behaviour with unit tests

## Testing
- PYTHONPATH=src pytest tests/test_openai_client.py *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68e511ebcc648330bf6a3d2636897d5d