### PR TITLE
Handle OpenAI response logging failures

### DIFF
--- a/src/video_gen/providers/openai_client.py
+++ b/src/video_gen/providers/openai_client.py
@@ -95,6 +95,11 @@ class OpenAIWorkflowClient:
             response_payload = response.model_dump()
         except AttributeError:  # pragma: no cover - defensive
             response_payload = str(response)
+        except Exception:  # pragma: no cover - defensive
+            try:
+                response_payload = response.model_dump_json()
+            except Exception:
+                response_payload = str(response)
         LOGGER.info("Received OpenAI response: %s", response_payload)
         content = response.choices[0].message.content
         if not content:


### PR DESCRIPTION
## Summary
- ensure the OpenAI workflow client always logs the received response payload
- fall back to alternate serialisation methods when model_dump is unavailable

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'video_gen')*


------
https://chatgpt.com/codex/tasks/task_e_68e522e32a948330a4c41e245246d124