### PR TITLE
Handle structured OpenAI message content

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -3,6 +3,41 @@
 from video_gen.providers.openai_client import OpenAIWorkflowClient
 
 
+class DummyMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_extract_message_content_from_structured_parts() -> None:
+    message = DummyMessage(
+        [
+            {"type": "text", "text": "{\n  \"sections\": ["},
+            {"type": "text", "text": "{\"section\": \"intro\", \"summary\": \"Hi\"}"},
+            {"type": "text", "text": "]\n}"},
+        ]
+    )
+
+    content = OpenAIWorkflowClient._extract_message_content(message)
+
+    assert content == '{\n  "sections": [{"section": "intro", "summary": "Hi"}]\n}'
+
+
+class DumpingMessage:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self):
+        return self._payload
+
+
+def test_extract_message_content_from_model_dump_payload() -> None:
+    message = DumpingMessage({"content": [{"type": "text", "text": "Hello"}]})
+
+    content = OpenAIWorkflowClient._extract_message_content(message)
+
+    assert content == "Hello"
+
+
 def test_parse_script_sections_from_plain_string() -> None:
     data = {"sections": "Intro paragraph.\n\nSecond paragraph."}
 


### PR DESCRIPTION
## Summary
- normalise OpenAI chat message payloads so structured content parts are flattened
- ensure workflow parsing uses the normalised content when decoding responses
- add regression tests covering structured message parts and model_dump payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e528fb6bc48330b580358ba92ae4e0